### PR TITLE
fix TypeError by checking if bbox is not None

### DIFF
--- a/RedArrow.roboFontExt/lib/outlineTestPen.py
+++ b/RedArrow.roboFontExt/lib/outlineTestPen.py
@@ -509,25 +509,26 @@ class OutlineTestPen(BasePointToSegmentPen):
 	
 	def _checkFractionalTransformation(self, baseGlyph, transformation):
 		bbox = get_bounds(self.glyphSet, baseGlyph)
-		tbox = transform_bbox(bbox, transformation)
-		if self.fractional_ignore_point_zero:
-			for p in transformation:
-				if round(p) != p:
-					self.errors.append(OutlineError(
-						half_point((tbox[0], tbox[1]), (tbox[2], tbox[3])),
-						"Fractional transformation", # (%0.2f, %0.2f, %0.2f, %0.2f, %0.2f, %0.2f)" % transformation
-						vector = None,
-					))
-					break
-		else:
-			for p in transformation:
-				if type(p) == float:
-					self.errors.append(OutlineError(
-						half_point((tbox[0], tbox[1]), (tbox[2], tbox[3])),
-						"Fractional transformation", # (%0.2f, %0.2f, %0.2f, %0.2f, %0.2f, %0.2f)" % transformation
-						vector = None,
-					))
-					break
+		if bbox:
+			tbox = transform_bbox(bbox, transformation)
+			if self.fractional_ignore_point_zero:
+				for p in transformation:
+					if round(p) != p:
+						self.errors.append(OutlineError(
+							half_point((tbox[0], tbox[1]), (tbox[2], tbox[3])),
+							"Fractional transformation", # (%0.2f, %0.2f, %0.2f, %0.2f, %0.2f, %0.2f)" % transformation
+							vector = None,
+						))
+						break
+			else:
+				for p in transformation:
+					if type(p) == float:
+						self.errors.append(OutlineError(
+							half_point((tbox[0], tbox[1]), (tbox[2], tbox[3])),
+							"Fractional transformation", # (%0.2f, %0.2f, %0.2f, %0.2f, %0.2f, %0.2f)" % transformation
+							vector = None,
+						))
+						break
 	
 	def _checkIncorrectSmoothConnection(self, pt, next_ref):
 		'''Test for incorrect smooth connections.'''


### PR DESCRIPTION
Came across a TypeError when a glyph contained an empty component in an in-progress font. Checking if the get_bounds function returns bounds and not none fixes the error for me. But I’m not 100% sure it this is the perfect place to check for this.